### PR TITLE
Show total number of items in inbox

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,4 +1,4 @@
-﻿var occLoader = function() {
+var occLoader = function() {
 
     var setBA = OCC.setBA,
     notify = OCC.notify,


### PR DESCRIPTION
It is possible to let outlook [show the total number of items](http://email.about.com/od/outlooktips/qt/See_Total_Not_Just_Unread_Inbox_Message_Count_in_Outlook.htm) in the inbox, not just the number of unread items. When that has been set, it will also show that way in OWA. This patch allows owa-chrome to detect the number of mails in the inbox. Otherwise it will never show any new mail.
